### PR TITLE
Fix bug, false positive

### DIFF
--- a/CleanRepo/CleanRepo.csproj
+++ b/CleanRepo/CleanRepo.csproj
@@ -44,6 +44,7 @@
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>
     </CodeAnalysisRuleSet>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -60,6 +61,9 @@
     <OutputPath>bin\Linux\</OutputPath>
     <CodeAnalysisRuleSet>
     </CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject>CleanRepo.Program</StartupObject>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="CommandLine, Version=1.9.71.2, Culture=neutral, PublicKeyToken=de6f01bd326f8c32, processorArchitecture=MSIL">

--- a/CleanRepo/Program.cs
+++ b/CleanRepo/Program.cs
@@ -526,7 +526,7 @@ namespace CleanRepo
                     if (fullPath != null)
                     {
                         // See if our constructed path matches the actual file we think it is
-                        if (String.Compare(fullPath, linkedFile.FullName) == 0)
+                        if (String.Compare(fullPath, linkedFile.FullName, true) == 0)
                         {
                             return true;
                         }
@@ -779,7 +779,7 @@ namespace CleanRepo
                     if (fullPath != null)
                     {
                         // See if our constructed path matches the actual file we think it is
-                        if (String.Compare(fullPath, linkedFile.FullName) == 0)
+                        if (String.Compare(fullPath, linkedFile.FullName, true) == 0)
                         {
                             return true;
                         }


### PR DESCRIPTION
Fixed a bug where the tool incorrectly reported "topics that were not in any TOC":

Before this fix the [azure-docs-pr](https://github.com/MicrosoftDocs/azure-docs-pr) repo, at the cognitive services directory there were some false positives. This was a simple matter of a few checks that were missing the `ignoreCase` bit with various string comparisons.

```
CleanRepo -o -d "C:\Repos\azure-docs-pr\articles\cognitive-services"

Searching the 'C:\Repos\azure-docs-pr\articles\cognitive-services' directory and its subdirectories for orphaned topics...

Topics not in any TOC file:

C:\Repos\azure-docs-pr\articles\cognitive-services\Academic-Knowledge\GraphSearchMethod.md
C:\Repos\azure-docs-pr\articles\cognitive-services\Academic-Knowledge\JSONSearchSyntax.md
C:\Repos\azure-docs-pr\articles\cognitive-services\Academic-Knowledge\LambdaSearchSyntax.md
C:\Repos\azure-docs-pr\articles\cognitive-services\Anomaly-Detector\How-to\identify-anomalies.md
C:\Repos\azure-docs-pr\articles\cognitive-services\Bing-Entities-Search\rank-results.md
C:\Repos\azure-docs-pr\articles\cognitive-services\Bing-Image-Search\quick-start.md
C:\Repos\azure-docs-pr\articles\cognitive-services\Bing-Web-Search\csharp-ranking-tutorial.md
C:\Repos\azure-docs-pr\articles\cognitive-services\Bing-Web-Search\quick-start.md
C:\Repos\azure-docs-pr\articles\cognitive-services\Computer-vision\QuickStarts\curl-disk.md
C:\Repos\azure-docs-pr\articles\cognitive-services\Content-Moderator\content-moderator-helper-quickstart-dotnet.md
C:\Repos\azure-docs-pr\articles\cognitive-services\Content-Moderator\Review-Tool-User-Guide\Upload-Images.md
C:\Repos\azure-docs-pr\articles\cognitive-services\immersive-reader\overview.md
C:\Repos\azure-docs-pr\articles\cognitive-services\immersive-reader\quickstart.md
C:\Repos\azure-docs-pr\articles\cognitive-services\QnAMaker\FAQs.md
C:\Repos\azure-docs-pr\articles\cognitive-services\QnAMaker\How-To\chit-chat-knowledge-base.md
C:\Repos\azure-docs-pr\articles\cognitive-services\QnAMaker\How-To\improve-knowledge-base.md
C:\Repos\azure-docs-pr\articles\cognitive-services\QnAMaker\Quickstarts\get-answer-from-kb-using-curl.md
C:\Repos\azure-docs-pr\articles\cognitive-services\text-analytics\how-tos\text-analytics-how-to-access-key.md
C:\Repos\azure-docs-pr\articles\cognitive-services\text-analytics\how-tos\text-analytics-how-to-call-api.md
C:\Repos\azure-docs-pr\articles\cognitive-services\text-analytics\how-tos\text-analytics-how-to-entity-linking.md
C:\Repos\azure-docs-pr\articles\cognitive-services\text-analytics\how-tos\text-analytics-how-to-keyword-extraction.md
C:\Repos\azure-docs-pr\articles\cognitive-services\text-analytics\how-tos\text-analytics-how-to-language-detection.md
C:\Repos\azure-docs-pr\articles\cognitive-services\text-analytics\how-tos\text-analytics-how-to-sentiment-analysis.md
C:\Repos\azure-docs-pr\articles\cognitive-services\text-analytics\how-tos\text-analytics-how-to-signup.md
C:\Repos\azure-docs-pr\articles\cognitive-services\text-analytics\how-tos\text-analytics-how-to-use-container-instance.md
C:\Repos\azure-docs-pr\articles\cognitive-services\text-analytics\tutorials\tutorial-power-bi-key-phrases.md
C:\Repos\azure-docs-pr\articles\cognitive-services\translator-speech\overview.md

Found 27 total .md files that are not referenced in a TOC.
```

After this fix, it correctly reports only 10.

```
CleanRepo -o -d "C:\Repos\azure-docs-pr\articles\cognitive-services"

Searching the 'C:\Repos\azure-docs-pr\articles\cognitive-services' directory and its subdirectories for orphaned topics...

Topics not in any TOC file:

C:\Repos\azure-docs-pr\articles\cognitive-services\Academic-Knowledge\GraphSearchMethod.md
C:\Repos\azure-docs-pr\articles\cognitive-services\Academic-Knowledge\JSONSearchSyntax.md
C:\Repos\azure-docs-pr\articles\cognitive-services\Academic-Knowledge\LambdaSearchSyntax.md
C:\Repos\azure-docs-pr\articles\cognitive-services\Bing-Entities-Search\rank-results.md
C:\Repos\azure-docs-pr\articles\cognitive-services\Bing-Image-Search\quick-start.md
C:\Repos\azure-docs-pr\articles\cognitive-services\Bing-Web-Search\csharp-ranking-tutorial.md
C:\Repos\azure-docs-pr\articles\cognitive-services\Bing-Web-Search\quick-start.md
C:\Repos\azure-docs-pr\articles\cognitive-services\Computer-vision\QuickStarts\curl-disk.md
C:\Repos\azure-docs-pr\articles\cognitive-services\Content-Moderator\content-moderator-helper-quickstart-dotnet.md
C:\Repos\azure-docs-pr\articles\cognitive-services\Content-Moderator\Review-Tool-User-Guide\Upload-Images.md

Found 10 total .md files that are not referenced in a TOC.
```