### PR TITLE
Fixed a bug discovered when working with long file paths.

### DIFF
--- a/CleanRepo/Program.cs
+++ b/CleanRepo/Program.cs
@@ -428,8 +428,17 @@ namespace CleanRepo
             {
                 return Path.GetFullPath(path);
             }
-            catch
+            catch (Exception ex)
             {
+                if (ex is PathTooLongException)
+                {
+                    Console.WriteLine($"Unable to get full-path, path too long: {path}");
+                }
+                else
+                {
+                    Console.WriteLine($"Unable to get full-path: {ex.Message}");
+                }
+
                 return null;
             }
         }


### PR DESCRIPTION
Observed the `System.IO.PathTooLongException` when scanning for orphaned images. Fixed it and addressed a few other minor bits for clean up.

 - Instantiate dictionary with `StringComparer.OrdinalIgnoreCase` to allow for case insensitive key lookups, avoids calling `.ToLower()`
 - Introduced a local function to encapsulate the key lookup and incrementing on the file map, avoids unnecessary `try/catch (KeyNotFoundException)` handling
 - Added `TryGetFullPath` to prevent early exit of application on error, instead ignore paths that are too long for now
 - Safely attempt to delete images, if unable to -- log that out.