### PR TITLE
Softer delete of topics not following the rules

### DIFF
--- a/CleanRepo/Program.cs
+++ b/CleanRepo/Program.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
 
@@ -471,9 +472,10 @@ namespace CleanRepo
         /// </summary>
         private static void ListOrphanedTopics(List<FileInfo> tocFiles, List<FileInfo> markdownFiles, bool deleteOrphanedTopics)
         {
-            int countNotFound = 0;
+            var countNotFound = 0;
+            var countDeleted = 0;
 
-            StringBuilder output = new StringBuilder("\nTopics not in any TOC file:\n\n");
+            StringBuilder output = new StringBuilder("\nTopic details:\n\n");
 
             foreach (var markdownFile in markdownFiles)
             {
@@ -499,6 +501,8 @@ namespace CleanRepo
 
                 if (!found)
                 {
+                    ++ countNotFound;
+
                     // Try to delete the file if the option is set.
                     if (deleteOrphanedTopics)
                     {
@@ -523,7 +527,7 @@ namespace CleanRepo
                         }
                         else
                         {
-                            ++ countNotFound;
+                            ++ countDeleted;
                             output.AppendLine($"Deleting '{markdownFile.FullName}'.");
 
                             File.Delete(markdownFile.FullName);
@@ -532,8 +536,8 @@ namespace CleanRepo
                 }
             }
 
-            var deleted = deleteOrphanedTopics ? "and deleted " : "";
-            output.AppendLine($"\nFound {deleted}{countNotFound} total .md files that are not referenced in a TOC.\n");
+            var deletedMessage = deleteOrphanedTopics ? $"Deleted {countDeleted} of these files." : "";
+            output.AppendLine($"\nFound { countNotFound} .md files that aren't referenced in a TOC. {deletedMessage}\n");
             Console.Write(output.ToString());
         }
 


### PR DESCRIPTION
The orphaned topic rules have now been expanded a bit to prevent the accidental deletion of topics that are referenced in another file.

### Updated Rules (Rule 3 is the addition)

1. A topic (`*.md`) file is **not** found in any `TOC` or `index` file
1. A topic (`*.md`) file is **not** found in in a `_shared` or `includes` directory
1. A topic (`*.md`) file is **not** linked or referenced by another `*.md` file

Fixed an issue where the clean repo tool was deleting topics that were actually linked in another file. I've updated the output to show what file it is referenced in, and a message indicating that it cannot be deleted.

```
CleanRepo -o -g -d "C:\Repos\azure-docs-pr\articles\cognitive-services"

Searching the 'C:\Repos\azure-docs-pr\articles\cognitive-services' directory and its subdirectories for orphaned topics...

Topics not in any TOC file:

Deleting 'C:\Repos\azure-docs-pr\articles\cognitive-services\Academic-Knowledge\GraphSearchMethod.md'.
Deleting 'C:\Repos\azure-docs-pr\articles\cognitive-services\Academic-Knowledge\JSONSearchSyntax.md'.
Deleting 'C:\Repos\azure-docs-pr\articles\cognitive-services\Academic-Knowledge\LambdaSearchSyntax.md'.
Unable to delete 'C:\Repos\azure-docs-pr\articles\cognitive-services\Bing-Entities-Search\rank-results.md'
    It is referenced in 'C:\Repos\azure-docs-pr\articles\cognitive-services\Bing-Entities-Search\tutorial-bing-entities-search-single-page-app.md'
Deleting 'C:\Repos\azure-docs-pr\articles\cognitive-services\Bing-Image-Search\quick-start.md'.
Unable to delete 'C:\Repos\azure-docs-pr\articles\cognitive-services\Bing-Web-Search\csharp-ranking-tutorial.md'
    It is referenced in 'C:\Repos\azure-docs-pr\articles\cognitive-services\Bing-Web-Search\rank-results.md'
Deleting 'C:\Repos\azure-docs-pr\articles\cognitive-services\Bing-Web-Search\quick-start.md'.
Deleting 'C:\Repos\azure-docs-pr\articles\cognitive-services\Computer-vision\QuickStarts\curl-disk.md'.
Deleting 'C:\Repos\azure-docs-pr\articles\cognitive-services\Content-Moderator\content-moderator-helper-quickstart-dotnet.md'.
Deleting 'C:\Repos\azure-docs-pr\articles\cognitive-services\Content-Moderator\Review-Tool-User-Guide\Upload-Images.md'.

Found and deleted 8 total .md files that are not referenced in a TOC.
```