### PR TITLE
BugFix-exact match for filename rather than partial

### DIFF
--- a/CleanRepo/Program.cs
+++ b/CleanRepo/Program.cs
@@ -349,7 +349,7 @@ namespace CleanRepo
                 // Look for a file of this name in the same directory to obtain its extension.
                 try
                 {
-                    FileInfo[] files = file.Directory.GetFiles(file.Name + "*");
+                    FileInfo[] files = file.Directory.GetFiles(file.Name + ".*");
                     if (files.Length > 0)
                     {
                         absolutePath = files[0].FullName;


### PR DESCRIPTION
Line 352 from * to .* for exact match of filename, not partial when using ` --relative-links`

Notes: Using partial match can cause an incorrect filename to be used since it grabs the first item in the array.

Examples of issues I ran into while using this on the SCCMDocs-pr repo with v1.3: 

- Replacing '](/sccm/core/clients/manage/manage-clients#restart-clients)' with '](../../core/clients/manage/manage-clients-for-linux-and-unix-servers.md#restart-clients)' in file 'C:\Program Files\Git\SCCMDocs-pr\sccm\apps\deploy-use\create-deploy-scripts.md'.

- Replacing '](/sccm/core/clients/deploy/about-client-installation-properties)' with '](about-client-installation-properties-published-to-active-directory-domain-services.md)' in file 'C:\Program Files\Git\SCCMDocs-pr\sccm\core\clients\deploy\deploy-clients-to-windows-computers.md'.
